### PR TITLE
Move `kitchen_sink_purifier_filter` resources

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -93,18 +93,6 @@
     target:
       entity_id: switch.bedroom_air_purifier
   mode: single
-- id: '1682293185693'
-  alias: Kitchen - Purifier - Set Kitchen Sink Purifier Filter Install Date
-  description: Set the kitchen sink purifier filter installed date to today
-  trigger: []
-  condition: []
-  action:
-  - service: input_datetime.set_datetime
-    data:
-      date: '{{ as_timestamp(now())|timestamp_custom(''%Y-%m-%d'') }}'
-    target:
-      entity_id: input_datetime.kitchen_sink_purifier_installed_date
-  mode: single
 - id: '1682293249148'
   alias: Air Purifier - Set bedroom air purifier install date to today
   description: Set the bedroom air purifier filter installed date to today

--- a/input_button.yaml
+++ b/input_button.yaml
@@ -13,9 +13,3 @@ bedroom_air_filter_change_to_today:
 hvac_filter_change_to_today:
   name: 'HVAC Filter Change to Today'
   icon: 'mdi:hvac'
-
-# Kitchen Sink Purifier
-kitchen_sink_purifier_change_to_today:
-  name: Kitchen Sink Purifier Change to Today
-  icon: mdi:cup-water
-

--- a/input_datetimes/input_datetime.yaml
+++ b/input_datetimes/input_datetime.yaml
@@ -17,10 +17,3 @@ hvac_filter_installed_date:
   icon: 'mdi:hvac'
   has_date: true
   has_time: false
-
-# Kitchen Sink Purifier
-kitchen_sink_purifier_installed_date:
-  name: 'Kitchen Sink Purifier Installed Date'
-  icon: 'mdi:cup-water'
-  has_date: true
-  has_time: false

--- a/input_datetimes/kitchen_sink_purifier_filter_install_date.yaml
+++ b/input_datetimes/kitchen_sink_purifier_filter_install_date.yaml
@@ -1,0 +1,10 @@
+---
+################################################################################
+# The date the kitchen sink purifier filter was last installed
+# https://www.home-assistant.io/integrations/input_datetime/
+################################################################################
+kitchen_sink_purifier_filter_install_date:
+  name: 'Kitchen Sink Purifier Filter Install Date'
+  icon: 'mdi:cup-water'
+  has_date: true
+  has_time: false

--- a/input_numbers/kitchen_sink_purifier_filter_lifespan.yaml
+++ b/input_numbers/kitchen_sink_purifier_filter_lifespan.yaml
@@ -1,0 +1,14 @@
+---
+################################################################################
+# The number of days the kitchen sink purifier filter is considered usable
+# https://www.home-assistant.io/integrations/input_number/
+################################################################################
+kitchen_sink_purifier_filter_lifespan:
+  name: 'Kitchen Sink Purifier Filter Lifespan'
+  initial: 180
+  min: 0
+  max: 365
+  step: 1
+  mode: box
+  unit_of_measurement: days
+  icon: mdi:history

--- a/scripts/kitchen_sink_purifier_filter_install_date_reset.yaml
+++ b/scripts/kitchen_sink_purifier_filter_install_date_reset.yaml
@@ -1,0 +1,16 @@
+---
+################################################################################
+# Set the kitchen sink purifier filter installed date to today
+# https://www.home-assistant.io/integrations/script/
+################################################################################
+kitchen_sink_purifier_filter_install_date_reset:
+  alias: Kitchen Sink Purifier Filter Install Date Reset
+  description: >
+    Set the kitchen sink purifier filter install date to today
+
+  sequence:
+    - action: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.kitchen_sink_purifier_filter_install_date
+      data:
+        date: '{{ as_timestamp(now()) | timestamp_custom(''%Y-%m-%d'') }}'

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -75,21 +75,6 @@
         {{ (((installed + diff) - now) / 86400) | round(0) }}
 
 ################################################################################
-# Kitchen Sink Filter Days Remaining
-################################################################################
-- platform: template
-  sensors:
-    kitchen_sink_purifier_days_remaining:
-      friendly_name: 'Kitchen Sink Purifier Days Remaining'
-      unit_of_measurement: days
-      icon_template: 'mdi:calendar-clock'
-      value_template: >-
-        {%- set installed = as_timestamp(states('input_datetime.kitchen_sink_purifier_installed_date')) -%}
-        {%- set diff = states('input_number.kitchen_sink_purifier_lifespan') | int * 86400 -%}
-        {%- set now = as_timestamp(states('sensor.date')) -%}
-        {{ (((installed + diff) - now) / 86400) | round(0) }}
-
-################################################################################
 # Time Date
 ################################################################################
 - platform: time_date

--- a/templates/sensors/kitchen_sink_purifier_filter_days_remaining.yaml
+++ b/templates/sensors/kitchen_sink_purifier_filter_days_remaining.yaml
@@ -1,0 +1,16 @@
+---
+################################################################################
+# Template for the number of days remaining before the kitchen sink purifier
+# filter needs to be changed
+# https://www.home-assistant.io/integrations/template/#sensor
+################################################################################
+- sensor:
+    name: Kitchen Sink Purifier Filter Days Remaining
+    unique_id: kitchen_sink_purifier_filter_days_remaining
+    unit_of_measurement: days
+    icon: mdi:calendar-clock
+    state: >
+      {% set installed = as_timestamp(states('input_datetime.kitchen_sink_purifier_filter_install_date')) %}
+      {% set lifespan = states('input_number.kitchen_sink_purifier_filter_lifespan') | int * 86400 %}
+      {% set now = as_timestamp(states('sensor.date')) %}
+      {{ (((installed + lifespan) - now) / 86400) | round(0) }}


### PR DESCRIPTION
### Changed
- Reorganize entities related to setting the `kitchen_sink_purifier_filter`.
- Do not use automation for filter change date, use script.
- Script action triggered from lovelace instead of `input_button`.